### PR TITLE
Remove copyright info in license file

### DIFF
--- a/license.html
+++ b/license.html
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright (C) 2010 Brockmann Consult GmbH (info@brockmann-consult.de)
-  ~
-  ~ This program is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU General Public License as published by the Free
-  ~ Software Foundation; either version 3 of the License, or (at your option)
-  ~ any later version.
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT
-  ~ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-  ~ FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-  ~ more details.
-  ~
-  ~ You should have received a copy of the GNU General Public License along
-  ~ with this program; if not, see http://www.gnu.org/licenses/
-  -->
-
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <html><head>


### PR DESCRIPTION
Revealed by running the update center XML generation tool, which reported several licenses are used.
